### PR TITLE
Build: Export typescript internally.

### DIFF
--- a/.changeset/rotten-sheep-sniff.md
+++ b/.changeset/rotten-sheep-sniff.md
@@ -1,0 +1,11 @@
+---
+'@nordcom/nordstar-heading': patch
+'@nordcom/nordstar-card': patch
+'@nordcom/nordstar-view': patch
+'@nordcom/nordstar': patch
+'@nordcom/nordstar-system': patch
+---
+
+Use typescript codebase directly during development internally.
+
+The `exports` get automatically replaced during packaging as a part of running `clean-package` in the `prepack` and `postpack` script(s).

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,7 +38,17 @@
         "editor.wordWrap": "off",
         "workbench.editor.restoreViewState": false
     },
-    "cSpell.words": ["Brandly", "Filiph", "Nordcom", "nordstar", "Sandström", "Siitam", "typecheck"],
+    "cSpell.words": [
+        "Brandly",
+        "Filiph",
+        "Nordcom",
+        "nordstar",
+        "postbuild",
+        "postpack",
+        "Sandström",
+        "Siitam",
+        "typecheck"
+    ],
     "markdown.extension.list.indentationSize": "inherit",
     "markdown.extension.toc.levels": "2..6",
     "markdown.extension.toc.omittedFromToc": {

--- a/clean-package.config.json
+++ b/clean-package.config.json
@@ -6,8 +6,8 @@
         "types": "dist/index.d.ts",
         "exports": {
             ".": {
-                "types": "./dist/index.d.ts",
-                "import": "./dist/index.js"
+                "import": "./dist/index.js",
+                "types": "./dist/index.d.ts"
             },
             "./package.json": "./package.json"
         }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     ],
     "prettier": "@nordcom/prettier",
     "scripts": {
-        "dev": "next dev --turbo",
+        "dev": "next dev",
         "build": "next build",
         "start": "next start -p $PORT",
         "lint": "concurrently npm:lint:*",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "name": "nordstar",
     "type": "module",
     "private": true,
-    "description": "Nordcom Group Inc.'s component library, a modern, accessible, beautiful, and flexible design system for building human user interfaces.",
     "main": "index.js",
     "prettier": "@nordcom/prettier",
     "workspaces": [
@@ -18,9 +17,9 @@
     },
     "scripts": {
         "prepare": "husky install",
-        "dev": "concurrently -i --raw npm:dev:*",
+        "dev": "concurrently -i --raw npm:dev:",
         "dev:docs": "turbo dev --filter=@nordcom/nordstar-docs",
-        "dev:packages": "turbo dev --filter=!@nordcom/nordstar-docs --filter=!@nordcom/nordstar-storybook",
+        "dev:packages": "",
         "dev:storybook": "turbo dev --filter=@nordcom/nordstar-storybook",
         "build": "turbo build",
         "build:docs": "turbo build --filter=@nordcom/nordstar-docs",

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -4,17 +4,13 @@
     "type": "module",
     "version": "0.0.10",
     "description": "",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        },
-        "./card": {
-            "import": "./dist/card.js",
-            "types": "./dist/card.d.ts"
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
         }
     },
     "sideEffects": false,
@@ -28,7 +24,9 @@
         "clean": "rimraf dist .turbo",
         "typecheck": "tsc --noEmit",
         "prepack": "clean-package",
-        "postpack": "clean-package restore"
+        "postpack": "clean-package restore",
+        "prebuild": "npm run prepack",
+        "postbuild": "npm run postpack"
     },
     "keywords": [
         "nordstar",

--- a/packages/components/heading/package.json
+++ b/packages/components/heading/package.json
@@ -4,17 +4,13 @@
     "type": "module",
     "version": "0.0.10",
     "description": "",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        },
-        "./heading": {
-            "import": "./dist/heading.js",
-            "types": "./dist/heading.d.ts"
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
         }
     },
     "sideEffects": false,
@@ -28,7 +24,9 @@
         "clean": "rimraf dist .turbo",
         "typecheck": "tsc --noEmit",
         "prepack": "clean-package",
-        "postpack": "clean-package restore"
+        "postpack": "clean-package restore",
+        "prebuild": "npm run prepack",
+        "postbuild": "npm run postpack"
     },
     "keywords": [
         "nordstar",

--- a/packages/components/heading/src/heading.stories.tsx
+++ b/packages/components/heading/src/heading.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from '@storybook/react';
+import React from 'react';
 import type { HeadingProps } from '../src';
 import { Heading } from '../src';
 

--- a/packages/components/view/package.json
+++ b/packages/components/view/package.json
@@ -4,17 +4,13 @@
     "type": "module",
     "version": "0.0.10",
     "description": "",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        },
-        "./view": {
-            "import": "./dist/view.js",
-            "types": "./dist/view.d.ts"
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
         }
     },
     "sideEffects": false,
@@ -28,7 +24,9 @@
         "clean": "rimraf dist .turbo",
         "typecheck": "tsc --noEmit",
         "prepack": "clean-package",
-        "postpack": "clean-package restore"
+        "postpack": "clean-package restore",
+        "prebuild": "npm run prepack",
+        "postbuild": "npm run postpack"
     },
     "keywords": [
         "nordstar",

--- a/packages/components/view/src/view.stories.tsx
+++ b/packages/components/view/src/view.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from '@storybook/react';
+import React from 'react';
 import type { ViewProps } from '../src';
 import { View } from '../src';
 
@@ -10,7 +11,7 @@ const story: Meta<typeof View> = {
 
 const Template = (args: ViewProps) => <View {...args}>You view&apos;s content goes here!</View>;
 
-export const Standard = {
+export const Default = {
     render: Template,
     args: {}
 };

--- a/packages/core/nordstar/package.json
+++ b/packages/core/nordstar/package.json
@@ -4,13 +4,13 @@
     "type": "module",
     "version": "0.0.10",
     "description": "",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
         }
     },
     "sideEffects": false,
@@ -52,7 +52,9 @@
         "clean": "rimraf dist .turbo",
         "typecheck": "tsc --noEmit",
         "prepack": "clean-package",
-        "postpack": "clean-package restore"
+        "postpack": "clean-package restore",
+        "prebuild": "npm run prepack",
+        "postbuild": "npm run postpack"
     },
     "peerDependencies": {
         "react": ">=18",

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -4,21 +4,13 @@
     "type": "module",
     "version": "0.0.10",
     "description": "",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        },
-        "./nordstar-provider": {
-            "import": "./dist/nordstar-provider.js",
-            "types": "./dist/nordstar-provider.d.ts"
-        },
-        "./utils": {
-            "import": "./dist/utils.js",
-            "types": "./dist/utils.d.ts"
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
         }
     },
     "sideEffects": false,
@@ -60,7 +52,9 @@
         "clean": "rimraf dist .turbo",
         "typecheck": "tsc --noEmit",
         "prepack": "clean-package",
-        "postpack": "clean-package restore"
+        "postpack": "clean-package restore",
+        "prebuild": "npm run prepack",
+        "postbuild": "npm run postpack"
     },
     "peerDependencies": {
         "react": ">=18",

--- a/plop/component/package.json.hbs
+++ b/plop/component/package.json.hbs
@@ -4,17 +4,13 @@
     "type": "module",
     "version": "0.0.0",
     "description": "",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        },
-        "./{{componentName}}": {
-            "import": "./dist/{{componentName}}.js",
-            "types": "./dist/{{componentName}}.d.ts"
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
         }
     },
     "sideEffects": false,

--- a/plop/package/package.json.hbs
+++ b/plop/package/package.json.hbs
@@ -4,17 +4,13 @@
     "type": "module",
     "version": "0.0.0",
     "description": "",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        },
-        "./{{packageName}}": {
-            "import": "./dist/{{packageName}}.js",
-            "types": "./dist/{{packageName}}.d.ts"
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
         }
     },
     "sideEffects": false,


### PR DESCRIPTION
This gets replaced by `clean-package`.