### PR TITLE
Components: Add stub `<Header/>` component(s).

### DIFF
--- a/.changeset/gold-rush.md
+++ b/.changeset/gold-rush.md
@@ -1,0 +1,9 @@
+---
+"@nordcom/nordstar-header": patch
+"@nordcom/nordstar": patch
+---
+
+Components: Add (stub) `<Header />` component(s).
+
+These are currently being backported from https://shops.nordcom.io/
+and https://nordcom.io/ to standardize them.

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,6 @@
         }
     },
     "rules": {
-        "@typescript-eslint/consistent-type-imports": "error",
         "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
         "consistent-return": "error",
         "import/first": "off",

--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,12 @@
+{
+    "extends": ["development"],
+    "hints": {
+        "typescript-config/is-valid": "off",
+        "compat-api/css": [
+            "default",
+            {
+                "ignore": ["backdrop-filter", "font-smooth", "overscroll-behavior", "text-size-adjust"]
+            }
+        ]
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,7 @@
     },
     "cSpell.words": [
         "Brandly",
+        "compat",
         "Filiph",
         "Nordcom",
         "nordstar",

--- a/docs/src/app/layout.module.scss
+++ b/docs/src/app/layout.module.scss
@@ -1,3 +1,15 @@
+.header {
+    position: sticky;
+    top: 0;
+
+    .logo {
+        display: contents;
+        font-size: 1.5em;
+        font-weight: 800;
+        line-height: 1;
+    }
+}
+
 .footer {
     display: grid;
     grid-auto-flow: column;

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,8 +1,9 @@
 import '@/styles/base.scss';
 
-import { Card, NordstarProvider, View } from '@nordcom/nordstar';
+import { Card, Header, NordstarProvider, View } from '@nordcom/nordstar';
 import type { Metadata, Viewport } from 'next';
 import { Montserrat } from 'next/font/google';
+import Link from 'next/link';
 import styles from './layout.module.scss';
 
 const font = Montserrat({
@@ -46,6 +47,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                         }
                     }}
                 >
+                    <Header className={styles.header}>
+                        <Header.Logo className={styles.logo}>nordstar</Header.Logo>
+                        <Header.Menu>
+                            <Header.Menu.Link as={Link} href="/">
+                                Home
+                            </Header.Menu.Link>
+                            <Header.Menu.Link as={Link} href="/docs/" prefetch={false}>
+                                Docs
+                            </Header.Menu.Link>
+                            <Header.Menu.Link as={Link} href="/storybook/" prefetch={false}>
+                                Storybook
+                            </Header.Menu.Link>
+                        </Header.Menu>
+                    </Header>
+
                     {children}
 
                     <Card as={View} variant="solid" color="primary" className={styles.footer}>

--- a/docs/src/app/page.module.scss
+++ b/docs/src/app/page.module.scss
@@ -7,7 +7,6 @@
         display: flex;
         flex-direction: column;
         gap: calc(var(--layout-section-spacing) / 3);
-        padding-top: calc(var(--layout-section-spacing) * 2);
         padding-bottom: var(--layout-section-spacing);
         width: 52rem;
         max-width: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4060,6 +4060,10 @@
             "resolved": "docs",
             "link": true
         },
+        "node_modules/@nordcom/nordstar-header": {
+            "resolved": "packages/components/header",
+            "link": true
+        },
         "node_modules/@nordcom/nordstar-heading": {
             "resolved": "packages/components/heading",
             "link": true
@@ -23032,6 +23036,45 @@
             "peerDependencies": {
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "packages/components/header": {
+            "name": "@nordcom/nordstar-header",
+            "version": "0.0.35",
+            "license": "MIT",
+            "dependencies": {
+                "@nordcom/nordstar-card": "0.0.35",
+                "@nordcom/nordstar-system": "0.0.35",
+                "@nordcom/nordstar-view": "0.0.35"
+            },
+            "devDependencies": {
+                "@nordcom/prettier": "0.1.1",
+                "clean-package": "2.2.0",
+                "prettier": "3.1.1",
+                "react": "18.2.0"
+            },
+            "engines": {
+                "node": ">=18 <=21",
+                "npm": ">=8"
+            },
+            "peerDependencies": {
+                "react": ">=18",
+                "react-dom": ">=18"
+            }
+        },
+        "packages/components/header/node_modules/prettier": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "packages/components/heading": {

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -26,7 +26,9 @@ const Card = forwardRef<'section', CardProps>(
         const Tag = as || 'section';
         const classes = `${styles.container}${className ? ` ${className}` : ''}`;
 
-        return <Tag {...props} ref={ref} data-variant={variant} data-color={color} className={classes} />;
+        return (
+            <Tag ref={ref} draggable={false} {...props} data-variant={variant} data-color={color} className={classes} />
+        );
     }
 );
 Card.displayName = 'Nordstar.Card';
@@ -41,7 +43,7 @@ export type CardDividerProps = {} & ComponentProps<'hr'>;
 const Divider = ({ className, ...props }: CardDividerProps) => {
     const classes = `${styles.divider}${className ? ` ${className}` : ''}`;
 
-    return <section {...props} className={classes} />;
+    return <section draggable={false} {...props} className={classes} />;
 };
 Divider.displayName = 'Nordstar.Card.Divider';
 

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -1,0 +1,12 @@
+# @nordcom/nordstar-header
+
+Standardized header component.
+
+## Installation
+
+> [!TIP]
+> This is an internal package and should probably not be installed by itself, but rather come as a dependency of `@nordcom/nordstar`.
+
+```sh
+npm install @nordcom/nordstar-header
+```

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "https://json.schemastore.org/package.json",
+    "name": "@nordcom/nordstar-header",
+    "type": "module",
+    "version": "0.0.35",
+    "description": "",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "module": "./src/index.ts",
+    "exports": {
+        ".": {
+            "import": "./src/index.ts",
+            "types": "./src/index.ts"
+        }
+    },
+    "sideEffects": false,
+    "engines": {
+        "npm": ">=8",
+        "node": ">=18 <=21"
+    },
+    "scripts": {
+        "build": "vite build",
+        "dev": "vite build --watch",
+        "clean": "rimraf dist .turbo",
+        "typecheck": "tsc --noEmit",
+        "prepack": "clean-package",
+        "postpack": "clean-package restore"
+    },
+    "keywords": [
+        "nordstar",
+        "nordcom",
+        "component",
+        "react",
+        "header",
+        "nordstar-header"
+    ],
+    "author": {
+        "name": "Nordcom Group Inc.",
+        "email": "opensource@nordcom.io",
+        "url": "https://nordcom.io/"
+    },
+    "contributors": [
+        {
+            "name": "Filiph Siitam Sandström",
+            "email": "filiph@nordcom.io",
+            "url": "https://github.com/filiphsps/"
+        }
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NordcomInc/nordstar.git",
+        "directory": "packages/components/header"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/NordcomInc/nordstar/issues"
+    },
+    "homepage": "https://nordstar.nordcom.io/docs/components/header/",
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "dependencies": {
+        "@nordcom/nordstar-system": "0.0.35",
+        "@nordcom/nordstar-card": "0.0.35",
+        "@nordcom/nordstar-view": "0.0.35"
+    },
+    "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+    },
+    "devDependencies": {
+        "@nordcom/prettier": "0.1.1",
+        "prettier": "3.1.1",
+        "clean-package": "2.2.0",
+        "react": "18.2.0"
+    },
+    "clean-package": "../../../clean-package.config.json"
+}

--- a/packages/components/header/src/header.module.scss
+++ b/packages/components/header/src/header.module.scss
@@ -1,0 +1,71 @@
+header.container {
+    z-index: 10;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 100%;
+    padding: var(--layout-page-spacing-half) var(--layout-page-spacing);
+
+    border-radius: 0;
+    border: none;
+    border-bottom: var(--border-width-half) solid var(--color-background-highlight);
+    -webkit-backdrop-filter: saturate(220%) blur(8px);
+    backdrop-filter: saturate(220%) blur(8px);
+    background-color: rgba(0, 0, 0, 0.75);
+
+    .content {
+        display: grid;
+        grid-template-columns: 1fr;
+        align-items: center;
+        justify-content: center;
+        gap: var(--layout-block-padding);
+
+        width: 100%;
+        height: 100%;
+        padding: 0;
+        margin: 0;
+
+        border: none;
+
+        @media (min-width: 950px) {
+            grid-template-columns: 1fr auto;
+        }
+
+        .logo {
+            img {
+                height: 100%;
+            }
+        }
+
+        .nav {
+            display: flex;
+            align-items: center;
+            gap: var(--layout-block-padding);
+
+            width: 100%;
+
+            -webkit-user-select: none;
+            user-select: none;
+
+            @media (min-width: 950px) {
+                gap: var(--layout-block-padding-double);
+            }
+
+            .link {
+                cursor: pointer;
+
+                font-size: 1.05em;
+                line-height: 1;
+                font-weight: 800;
+                text-transform: uppercase;
+
+                transition: color ease-in-out var(--duration-short);
+
+                &:is(:hover, :active) {
+                    color: var(--color-accent-primary);
+                }
+            }
+        }
+    }
+}

--- a/packages/components/header/src/header.stories.tsx
+++ b/packages/components/header/src/header.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta } from '@storybook/react';
+import React from 'react';
+import type { HeaderLogoProps, HeaderMenuProps, HeaderProps } from '../src';
+import { Header } from '../src';
+
+const story: Meta<typeof Header> = {
+    title: 'Components/Header',
+    component: Header,
+    argTypes: {}
+};
+
+const Template = ({
+    headerArgs,
+    logoArgs,
+    menuArgs
+}: {
+    headerArgs: HeaderProps;
+    logoArgs: HeaderLogoProps;
+    menuArgs: HeaderMenuProps;
+}) => (
+    <Header {...headerArgs}>
+        <Header.Logo {...logoArgs} />
+        <Header.Menu {...menuArgs} />
+    </Header>
+);
+
+export const Default = {
+    render: Template,
+    args: {
+        headerArgs: {},
+        logoArgs: {
+            children: <b>hello world</b>
+        },
+        menuArgs: {
+            children: (
+                <>
+                    <Header.Menu.Link>Link 1</Header.Menu.Link>
+                    <Header.Menu.Link>Link 2</Header.Menu.Link>
+                    <Header.Menu.Link>Link 3</Header.Menu.Link>
+                </>
+            )
+        }
+    }
+};
+
+export default story;

--- a/packages/components/header/src/header.test.tsx
+++ b/packages/components/header/src/header.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom';
+
+import { describe, expect, it } from 'vitest';
+
+import { Header } from '../src';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+describe('components', () => {
+    describe('header', () => {
+        describe('Header', () => {
+            it('should render correctly', () => {
+                const wrapper = render(<Header />);
+
+                expect(() => wrapper.unmount()).not.toThrow();
+            });
+        });
+    });
+});

--- a/packages/components/header/src/header.tsx
+++ b/packages/components/header/src/header.tsx
@@ -1,0 +1,70 @@
+import { Card } from '@nordcom/nordstar-card';
+import { As, CSSCustomProperties, NordstarColor, forwardRef } from '@nordcom/nordstar-system';
+import { View } from '@nordcom/nordstar-view';
+import { ComponentProps } from 'react';
+import styles from './header.module.scss';
+
+export type HeaderProps = {
+    color?: NordstarColor;
+    style?: CSSCustomProperties;
+} & ComponentProps<'header'>;
+
+const Header = ({ className, children, ...props }: HeaderProps) => {
+    const classes = `${styles.container}${className ? ` ${className}` : ''}`;
+
+    return (
+        <Card as="header" {...props} className={classes}>
+            <View as="div" className={styles.content} withoutWrapper={true}>
+                {children}
+            </View>
+        </Card>
+    );
+};
+Header.displayName = 'Nordstar.Header';
+
+export type HeaderLogoProps = {} & ComponentProps<'nav'>;
+
+/**
+ * `<Header.Logo/>`, a component to render a header's logo.
+ * @param {object} props - `<Header.Logo/>` props.
+ * @returns {React.ReactNode} The `<Header.Logo/>` component.
+ */
+const Logo = ({ className, ...props }: HeaderLogoProps) => {
+    const classes = `${styles.logo}${className ? ` ${className}` : ''}`;
+
+    return <section {...props} draggable={false} className={classes} />;
+};
+Logo.displayName = 'Nordstar.Header.Logo';
+
+export type HeaderMenuProps = {} & ComponentProps<'nav'>;
+
+/**
+ * `<Header.Menu/>`, a component to render a header's content.
+ * @param {object} props - `<Header.Menu/>` props.
+ * @returns {React.ReactNode} The `<Header.Menu/>` component.
+ */
+const Menu = ({ className, ...props }: HeaderMenuProps) => {
+    const classes = `${styles.nav}${className ? ` ${className}` : ''}`;
+
+    return <nav {...props} draggable={false} className={classes} />;
+};
+Menu.displayName = 'Nordstar.Header.Menu';
+
+export type HeaderMenuLinkProps = {
+    as?: As;
+};
+
+/**
+ * `<Header.Menu.Link/>`, a component to render header links.
+ * @param {object} props - `<Header.Menu.Link/>` props.
+ * @returns {React.ReactNode} The `<Header.Menu.Link/>` component.
+ */
+const Link = forwardRef<'a', HeaderMenuLinkProps>(({ as, className, ...props }, ref) => {
+    const Tag = as || 'a';
+    const classes = `${styles.link}${className ? ` ${className}` : ''}`;
+
+    return <Tag ref={ref} draggable={false} {...props} className={classes} />;
+});
+Link.displayName = 'Nordstar.Header.Menu.Link';
+
+export default Object.assign(Header, { Logo, Menu: Object.assign(Menu, { Link }) });

--- a/packages/components/header/src/index.ts
+++ b/packages/components/header/src/index.ts
@@ -1,0 +1,5 @@
+import Header from './header';
+
+export type { HeaderLogoProps, HeaderMenuLinkProps, HeaderMenuProps, HeaderProps } from './header';
+
+export { Header };

--- a/packages/components/header/tsconfig.json
+++ b/packages/components/header/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": "./",
+        "rootDir": "./src",
+        "outDir": "dist"
+    },
+    "exclude": ["node_modules", "dist", "**/*.test.*", "**/*.stories.*"],
+    "extends": "../../tsconfig.json",
+    "include": ["./src/**/*.ts", "./**/*.tsx", "../../../@types/declaration.d.ts"]
+}

--- a/packages/components/header/vite.config.ts
+++ b/packages/components/header/vite.config.ts
@@ -1,0 +1,21 @@
+import { resolve } from 'node:path';
+import { defineConfig, mergeConfig } from 'vite';
+
+import base from '../vite.config';
+
+export default mergeConfig(
+    base,
+    defineConfig({
+        root: resolve(__dirname),
+        build: {
+            lib: {
+                entry: ['src/header.tsx']
+            },
+            rollupOptions: {
+                output: {
+                    name: 'Nordstar.Component.Header'
+                }
+            }
+        }
+    })
+);

--- a/packages/core/nordstar/src/index.ts
+++ b/packages/core/nordstar/src/index.ts
@@ -1,5 +1,5 @@
 // Core
-import type {
+export type {
     As,
     InternalForwardRefRenderFunction,
     MergeWithAs,
@@ -10,38 +10,25 @@ import type {
     RightJoinProps
 } from '@nordcom/nordstar-system';
 import { NordstarProvider } from '@nordcom/nordstar-system';
-
-// Components
-import type { AccentedProps } from '@nordcom/nordstar-accented';
-import { Accented } from '@nordcom/nordstar-accented';
-import type { ButtonProps } from '@nordcom/nordstar-button';
-import { Button } from '@nordcom/nordstar-button';
-import type { CardProps } from '@nordcom/nordstar-card';
-import { Card } from '@nordcom/nordstar-card';
-import type { HeadingProps } from '@nordcom/nordstar-heading';
-import { Heading } from '@nordcom/nordstar-heading';
-import type { InputProps } from '@nordcom/nordstar-input';
-import { Input } from '@nordcom/nordstar-input';
-import type { LabelProps } from '@nordcom/nordstar-label';
-import { Label } from '@nordcom/nordstar-label';
-import type { ViewProps } from '@nordcom/nordstar-view';
 import { View } from '@nordcom/nordstar-view';
 
-export { Accented, Button, Card, Heading, Input, Label, NordstarProvider, View };
-export type {
-    AccentedProps,
-    As,
-    ButtonProps,
-    CardProps,
-    HeadingProps,
-    InputProps,
-    InternalForwardRefRenderFunction,
-    LabelProps,
-    MergeWithAs,
-    NordstarProviderProps,
-    NordstarTheme,
-    OmitCommonProps,
-    PropsOf,
-    RightJoinProps,
-    ViewProps
-};
+// Components
+import { Accented } from '@nordcom/nordstar-accented';
+import { Button } from '@nordcom/nordstar-button';
+import { Card } from '@nordcom/nordstar-card';
+import { Header } from '@nordcom/nordstar-header';
+import { Heading } from '@nordcom/nordstar-heading';
+import { Input } from '@nordcom/nordstar-input';
+import { Label } from '@nordcom/nordstar-label';
+
+// Component Types
+export type { AccentedProps } from '@nordcom/nordstar-accented';
+export type { ButtonProps } from '@nordcom/nordstar-button';
+export type { CardDividerProps, CardProps } from '@nordcom/nordstar-card';
+export type { HeaderLogoProps, HeaderMenuLinkProps, HeaderMenuProps, HeaderProps } from '@nordcom/nordstar-header';
+export type { HeadingProps } from '@nordcom/nordstar-heading';
+export type { InputProps } from '@nordcom/nordstar-input';
+export type { LabelProps } from '@nordcom/nordstar-label';
+export type { ViewProps } from '@nordcom/nordstar-view';
+
+export { Accented, Button, Card, Header, Heading, Input, Label, NordstarProvider, View };

--- a/packages/core/system/src/nordstar-provider.tsx
+++ b/packages/core/system/src/nordstar-provider.tsx
@@ -84,12 +84,16 @@ export const NordstarProvider = ({ children, theme, ...props }: NordstarProvider
 
             --layout-page-width: ${layout?.page?.width || '1200px'};
             --layout-page-spacing: ${layout?.page?.spacing || '1rem'};
+            --layout-page-spacing-half: calc(var(--layout-page-spacing) / 2);
 
             --layout-section-spacing: ${layout?.section?.spacing || '1rem'};
             --layout-section-padding: ${layout?.section?.padding || '1.75rem'};
 
             --layout-block-padding: ${layout?.block?.padding || '1rem'};
+            --layout-block-padding-double: calc(var(--layout-block-padding) * 2);
             --layout-block-padding-half: calc(var(--layout-block-padding) / 2);
+
+            --duration-short: 150ms;
         }
     `;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,7 +44,8 @@ export default defineConfig({
                 '**/src/app/{page,layout}.*',
                 '**/packages/**/src/index.*',
                 '**/*.css',
-                '**/dist/**/*.*'
+                '**/dist/**/*.*',
+                'packages/core/system/src/colors.ts'
             ],
             include: ['**/src/**/*.{js,ts,jsx,tsx}'],
             provider: 'v8'


### PR DESCRIPTION
This is a backport of the https://nordcom.io/ and
https://shops.nordcom.io/ headers as they make much more sense to be a part of the main UI library. :^)